### PR TITLE
Allow custom tags & update consistence/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require": {
 		"php": "~7.1",
 		"symfony/console": "~3.2|~4.0",
-		"symfony/yaml": "~3.0|~4.0"
+		"symfony/yaml": "~3.3|~4.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "3.8",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"symfony/yaml": "~3.0|~4.0"
 	},
 	"require-dev": {
-		"consistence/coding-standard": "2.3.1",
+		"consistence/coding-standard": "3.8",
 		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"phpstan/phpstan-shim": "0.9.2",
 		"phpunit/phpunit": "7.0.2"

--- a/src/SortCheckResult.php
+++ b/src/SortCheckResult.php
@@ -7,9 +7,7 @@ namespace Mhujer\YamlSortChecker;
 class SortCheckResult
 {
 
-	/**
-	 * @var string[]
-	 */
+	/** @var string[] */
 	private $messages;
 
 	/**

--- a/src/SortChecker.php
+++ b/src/SortChecker.php
@@ -24,7 +24,7 @@ class SortChecker
 	): SortCheckResult
 	{
 		try {
-			$data = Yaml::parse(file_get_contents($filename));
+			$data = Yaml::parse(file_get_contents($filename), Yaml::PARSE_CUSTOM_TAGS);
 
 			$errors = $this->areDataSorted($data, $excludedKeys, $excludedSections, null, $depth);
 

--- a/tests/SortCheckerTest.php
+++ b/tests/SortCheckerTest.php
@@ -16,6 +16,15 @@ class SortCheckerTest extends \PHPUnit\Framework\TestCase
 		$this->assertCount(0, $result->getMessages());
 	}
 
+	public function testSortedFileWithCustomTag(): void
+	{
+		$checker = new SortChecker();
+		$result = $checker->isSorted(__DIR__ . '/fixture/ok-tagged.yml', 10);
+
+		$this->assertTrue($result->isOk());
+		$this->assertCount(0, $result->getMessages());
+	}
+
 	public function testInvalidYamlIsInvalid(): void
 	{
 		$checker = new SortChecker();

--- a/tests/fixture/ok-tagged.yml
+++ b/tests/fixture/ok-tagged.yml
@@ -1,0 +1,8 @@
+services:
+    _instanceof:
+        NonexistentClassInterface:
+            tags: ['nonexistent_tag']
+
+    NonexistentClassImplementation:
+        arguments:
+            - !tagged nonexistent_tag


### PR DESCRIPTION
Yaml parser does not allow custom tags by default, but custom tags
are needed to use Symfony's shortcut to injecting tagged services
https://symfony.com/doc/current/service_container/tags.html#reference-tagged-services

Lowest symfony/yaml that support the custom tags is 3.1, thus I updated the requirements too

This PR also updates consistence/coding-standard to make this package buildable with php 7.3