### PR TITLE
WIP: Feature: scan dirs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	"require": {
 		"php": "~7.2",
 		"symfony/console": "~3.4|~4.3|~5.0",
+		"symfony/finder": "~3.4|~4.3|~5.0",
 		"symfony/yaml": "~3.4|~4.3|~5.0"
 	},
 	"require-dev": {

--- a/docs/symfony-config/yaml-sort-checker.yml
+++ b/docs/symfony-config/yaml-sort-checker.yml
@@ -14,9 +14,9 @@ files:
                 - host
                 - username
                 - password
-          excludedSections:
-            0: imports
-            1: parameters
+            excludedSections:
+                0: imports
+                1: parameters
 
     app/config/config_dev.yml:
         excludedKeys:

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Mhujer\YamlSortChecker;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
 class CheckCommand extends \Symfony\Component\Console\Command\Command
@@ -13,34 +15,38 @@ class CheckCommand extends \Symfony\Component\Console\Command\Command
 
 	protected function configure(): void
 	{
-		$this->setName('yaml-check-sort');
+		$this
+			->setName('yaml-check-sort')
+			->addArgument('config', InputArgument::OPTIONAL, 'Configuration filename', 'yaml-sort-checker.yml');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): ?int
 	{
 		$output->writeln('#### YAML Sort Checker ####');
 
-		$configFilePath = realpath('yaml-sort-checker.yml');
+		$config = $input->getArgument('config');
+		$configFilePath = is_string($config) ? realpath($config) : false;
 		if ($configFilePath === false) {
 			$output->writeln(sprintf('Config file "%s" not found!', 'yaml-sort-checker.yml'));
-			exit(1);
+			return 1;
 		}
 		$output->writeln(sprintf('Using config file "%s"', $configFilePath));
 
 		$configFileContents = file_get_contents($configFilePath);
 		if ($configFileContents === false) {
-			throw new \Exception(sprintf('File "%s" could not be loaded', $configFilePath));
+			$output->writeln(sprintf('File "%s" could not be loaded', $configFilePath));
+			return 1;
 		}
 		$config = Yaml::parse($configFileContents);
 
 		if (!array_key_exists('files', $config)) {
 			$output->writeln('There must be a key "files" in config');
-			exit(1);
+			return 1;
 		}
 
 		if (count($config['files']) === 0) {
 			$output->writeln('There must be some files in the config');
-			exit(1);
+			return 1;
 		}
 
 		$output->writeln('');
@@ -56,22 +62,27 @@ class CheckCommand extends \Symfony\Component\Console\Command\Command
 			$excludedKeys = array_key_exists('excludedKeys', $options) ? $options['excludedKeys'] : [];
 			$excludedSections = array_key_exists('excludedSections', $options) ? $options['excludedSections'] : [];
 
-			$output->write(sprintf('Checking %s: ', $filename));
-			if (realpath($filename) === false || !is_readable(realpath($filename))) {
-				$output->writeln('NOT READABLE!');
-				exit(1);
+			try {
+				$files = $this->resolveYmlFiles($filename);
+			} catch (\InvalidArgumentException $e) {
+				$output->writeln($e->getMessage());
+				return 1;
 			}
 
-			$sortCheckResult = $sortChecker->isSorted($filename, $depth, $excludedKeys, $excludedSections);
+			foreach ($files as $file) {
+				$output->write(sprintf('Checking %s: ', $file));
 
-			if ($sortCheckResult->isOk()) {
-				$output->writeln('OK');
-			} else {
-				$output->writeln('ERROR');
-				foreach ($sortCheckResult->getMessages() as $message) {
-					$output->writeln('  ' . $message);
+				$sortCheckResult = $sortChecker->isSorted($file, $depth, $excludedKeys, $excludedSections);
+
+				if ($sortCheckResult->isOk()) {
+					$output->writeln('OK');
+				} else {
+					$output->writeln('ERROR');
+					foreach ($sortCheckResult->getMessages() as $message) {
+						$output->writeln('  ' . $message);
+					}
+					$isOk = false;
 				}
-				$isOk = false;
 			}
 		}
 
@@ -79,9 +90,47 @@ class CheckCommand extends \Symfony\Component\Console\Command\Command
 		if (!$isOk) {
 			$output->writeln('Fix the YAMLs or exclude the keys in the config.');
 			return 1;
-		} else {
-			$output->writeln('All YAMLs are properly sorted.');
-			return 0;
+		}
+
+		$output->writeln('All YAMLs are properly sorted.');
+		return 0;
+	}
+
+	/**
+	 * @param string $filename
+	 * @return string[]
+	 */
+	private function resolveYmlFiles(string $filename): array
+	{
+		// Check if its file
+		$filepath = realpath($filename);
+		if ($filepath !== false && is_file($filepath) && is_readable($filepath)) {
+			return [$filename];
+		}
+
+		try {
+			// If not try to parse it as directory
+			$filesIterator = (new Finder())
+				->in($filename)
+				->name(['*.yml', '*.yaml'])
+				->ignoreUnreadableDirs(true)
+				->ignoreDotFiles(true)
+				->ignoreVCS(true)
+				->getIterator();
+
+			$files = [];
+			foreach ($filesIterator as $fileInfo) {
+				$fileRealPath = $fileInfo->getRealPath();
+				if ($fileRealPath === false || !is_readable($fileRealPath)) {
+					throw new \InvalidArgumentException(sprintf('File %s is not readable', $fileRealPath));
+				}
+
+				$files[] = $fileRealPath;
+			}
+
+			return $files;
+		} catch (\Throwable $e) {
+			throw new \InvalidArgumentException(sprintf('Unable to find files in %s', $filename));
 		}
 	}
 


### PR DESCRIPTION
Issue: #5 

Using symfony finder component I have managed to implement ability to define directories in config files in which yml/yaml files would be found for checking.

Remaining question:
currently all files inherit options defined by directory. Maybe it would be useful to exclude files from scanning if they are defined in config file? For example: if config file contains `app/config:` and next line `app/config/services.yml`, then I think we should exclude services.yml file from scanned files in app/config directory and use options defined under that concrete file.