### PR TITLE
Add PHP 8 support, update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
+  - 7.4
 
 env:
   - COMPOSER_DEPENDENCIES=""
   - COMPOSER_DEPENDENCIES="--prefer-lowest"
+
+jobs:
+  include:
+    - php: nightly
+      env: COMPOSER_DEPENDENCIES="--ignore-platform-reqs"
 
 install:
   - travis_retry composer update --no-interaction $COMPOSER_DEPENDENCIES

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,16 @@
 		"bin/yaml-sort-checker"
 	],
 	"require": {
-		"php": "~7.2",
+		"php": "~7.3 | ^8.0",
 		"symfony/console": "~3.4|~4.3|~5.0",
 		"symfony/yaml": "~3.4|~4.3|~5.0"
 	},
 	"require-dev": {
-		"consistence/coding-standard": "3.9",
-		"jakub-onderka/php-parallel-lint": "1.0.0",
-		"phpstan/phpstan-shim": "0.11.19",
-		"phpunit/phpunit": "8.4.3"
+		"consistence/coding-standard": "3.10.1",
+		"php-parallel-lint/php-parallel-lint": "1.2.0",
+		"phpstan/phpstan": "0.12.57",
+		"phpunit/phpunit": "9.4.3",
+		"slevomat/coding-standard": "6.4.1"
 	},
 	"autoload": {
 		"psr-4": {
@@ -51,7 +52,6 @@
 	},
 	"scripts": {
 		"build": [
-			"@composer install --no-progress --no-interaction --no-suggest",
 			"@phplint",
 			"@phpcs",
 			"@phpstan",
@@ -59,7 +59,7 @@
 		],
 		"phplint": "parallel-lint -j 10 --exclude vendor .",
 		"phpcs": "phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp bin src tests",
-		"phpstan": "@php vendor/phpstan/phpstan-shim/phpstan.phar analyse bin src tests --level 7 --no-progress",
+		"phpstan": "@php vendor/bin/phpstan analyse bin src tests --level 7 --no-progress",
 		"test": "phpunit"
 	},
 	"config": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -20,12 +20,9 @@
 			"/>
 		</properties>
 	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
 		<properties>
-			<property name="usefulAnnotations" type="array" value="
-				@dataProvider,
-				@see
-			"/>
+			<property name="enableNativeTypeHint" value="false"/>
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">


### PR DESCRIPTION
One dev-dependency (consistence/coding-standard) still requires php ~7.2 ([see issue](https://github.com/consistence/coding-standard/pull/65)). However it is dev-dependency, so should be safe to add ignore platform requirements for now.

All other dependencies are now also PHP 8 compatible.

```
$ composer why-not php:8
consistence/coding-standard  3.10.1  requires  php (~7.1)
```